### PR TITLE
add role column to users

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -4,7 +4,7 @@ class Admin::BaseController < ApplicationController
 
 
   def authenticate_admin
-    redirect_to root_path, notice: t('admin.not_admin') unless current_user.role == 'admin'
+    redirect_to root_path, notice: t('admin.not_admin') unless self.is_admin?
   end
 
 end

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -4,7 +4,7 @@ class Admin::BaseController < ApplicationController
 
 
   def authenticate_admin
-    redirect_to root_path, notice: t('admin.not_admin') unless self.is_admin?
+    redirect_to root_path, notice: t('admin.not_admin') unless is_admin?
   end
 
 end

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,10 @@
+class Admin::BaseController < ApplicationController
+  before_action :authenticate_admin
+  layout "admin"
+
+
+  def authenticate_admin
+    redirect_to root_path, notice: t('admin.not_admin') unless current_user.role == 'admin'
+  end
+
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,5 @@
 class Admin::UsersController < Admin::BaseController
-  before_action :find_user, only: %i[show destroy]
+  before_action :find_user, only: %i[edit update show destroy]
   before_action :search_user_tasks, only: [:show]
 
   def index
@@ -29,8 +29,7 @@ class Admin::UsersController < Admin::BaseController
   #管理者可以在頁面修改會員身份
   def update
     @user = User.find_by(id: params[:id])
-    @admin = current_user
-    if @admin.role == 'admin'
+    if self.is_admin?
       @user.update_columns(filter_params)
       redirect_to user_path(@user), notice: t('user.edit_t')
     else  

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,5 @@
 class Admin::UsersController < Admin::BaseController
-  before_action :find_user, only: %i[edit update show destroy]
+  before_action :find_user, only: %i[show destroy]
   before_action :search_user_tasks, only: [:show]
 
   def index
@@ -24,10 +24,14 @@ class Admin::UsersController < Admin::BaseController
   end
 
   def edit
+    @user = User.find_by(id: params[:id])
   end
-
+  #管理者可以在頁面修改會員身份
   def update
-    if @user.toggle!(filter_params)
+    @user = User.find_by(id: params[:id])
+    @admin = current_user
+    if @admin.role == 'admin'
+      @user.update_columns(filter_params)
       redirect_to user_path(@user), notice: t('user.edit_t')
     else  
       render :edit, notice: t('user.edit_f')
@@ -56,8 +60,8 @@ class Admin::UsersController < Admin::BaseController
   def user_params
     params.require(:user).permit(:username, :email, :password, :role)
   end
-
+  #因修改傳進來的資料會是一個object 所以要用to_h轉成hash
   def filter_params
-    user_params.select { |k, v| !v.blank? }
+    (user_params.select { |k, v| !v.blank? }).to_h
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -24,11 +24,9 @@ class Admin::UsersController < Admin::BaseController
   end
 
   def edit
-    @user = User.find_by(id: params[:id])
   end
   #管理者可以在頁面修改會員身份
   def update
-    @user = User.find_by(id: params[:id])
     if self.is_admin?
       @user.update_columns(filter_params)
       redirect_to user_path(@user), notice: t('user.edit_t')

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,4 +1,4 @@
-class Admin::UsersController < ApplicationController
+class Admin::UsersController < Admin::BaseController
   before_action :find_user, only: %i[edit update show destroy]
   before_action :search_user_tasks, only: [:show]
 
@@ -27,7 +27,7 @@ class Admin::UsersController < ApplicationController
   end
 
   def update
-    if @user.update(filter_params)
+    if @user.toggle!(filter_params)
       redirect_to user_path(@user), notice: t('user.edit_t')
     else  
       render :edit, notice: t('user.edit_f')
@@ -38,7 +38,7 @@ class Admin::UsersController < ApplicationController
     if @user.destroy
       redirect_to admin_users_path, notice: t('admin.destroy.notice')
     else  
-      redirect_to admin_users_path, notice: t('admin.destroy.notice_f')
+      redirect_to admin_users_path, notice: "#{@user.errors[:base]}"
     end
   end
 
@@ -54,7 +54,7 @@ class Admin::UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:username, :email, :password)
+    params.require(:user).permit(:username, :email, :password, :role)
   end
 
   def filter_params

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -27,7 +27,7 @@ class Admin::UsersController < Admin::BaseController
   end
   #管理者可以在頁面修改會員身份
   def update
-    if self.is_admin?
+    if is_admin?
       @user.update_columns(filter_params)
       redirect_to user_path(@user), notice: t('user.edit_t')
     else  

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   private
   include Sessions
   helper_method :current_user
+  helper_method :is_admin?
 
   def authenticate_user
     redirect_to login_path, notice: t('views.not_login') unless current_user

--- a/app/controllers/concerns/sessions.rb
+++ b/app/controllers/concerns/sessions.rb
@@ -17,6 +17,6 @@ module Sessions
   end
 
   def is_admin?
-    self.role == 'admin'
+    current_user&.role == 'admin'
   end
 end

--- a/app/controllers/concerns/sessions.rb
+++ b/app/controllers/concerns/sessions.rb
@@ -15,4 +15,8 @@ module Sessions
     session.delete(:user_id)
     @current_user = nil
   end
+
+  def is_admin?
+    self.role == 'admin'
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,9 +7,9 @@ class SessionsController < ApplicationController
   def create
     if @user && @user.authenticate(params[:session][:password])
       login @user
-      redirect_to root_path, notice: t('user.signup_t')
+      redirect_to root_path, notice: t('session.success')
     else  
-      render :new, notice: t('user.signup_f')
+      render :new, notice: t('session.unsuccess')
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -39,7 +39,7 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:username, :email, :password)
+    params.require(:user).permit(:username, :email, :password, :role)
   end
 
   def find_user

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -1,2 +1,10 @@
 module Admin::UsersHelper
+  def identity(role)
+    case role
+    when "menber"
+      t('admin.menber')
+    when "admin"
+      t('admin.admin')
+    end
+  end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,10 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  private
+
+  def halt(tag: :abort, attr: :base, msg: nil)
+    errors.add(attr, msg) if msg
+    throw(tag)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,5 +5,25 @@ class User < ApplicationRecord
   validates :email, presence: true, format: { with: validate_email }
   validates_uniqueness_of :email, :message => "你的 Email 重複了"
   validates :password, presence: true, length: { minimum: 6 }
+  before_destroy :final_admin
+  before_update :admin_edit
   has_secure_password
+
+  #檢查使用者身份是不是admin 如果admin剩最後一個 無法被刪除
+  def final_admin
+    return unless self.role == 'admin'
+    # if User.where(role: 'admin').count == 1
+      # errors.add(:base, "最後一位管理員無法刪除")
+      # throw :abort
+      if User.where(role: 'admin').count == 1
+        # halt msg: t('admin.final.admin')
+        halt msg: "最後一位使用者無法被刪除"
+      end
+  end
+
+  def admin_edit
+    if self.role == 'admin'
+      self.update_all
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,9 @@ class User < ApplicationRecord
   def final_admin
     return unless self.role == 'admin'
       if User.where(role: 'admin').count == 1
-        halt msg: "最後一位使用者無法被刪除"
+        errors.add(:base, I18n.t('admin.final_admin')) 
+        throw(:abort) 
+        # halt msg: I18n.t('admin.final_admin')
       end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,24 +6,14 @@ class User < ApplicationRecord
   validates_uniqueness_of :email, :message => "你的 Email 重複了"
   validates :password, presence: true, length: { minimum: 6 }
   before_destroy :final_admin
-  before_update :admin_edit
   has_secure_password
 
   #檢查使用者身份是不是admin 如果admin剩最後一個 無法被刪除
   def final_admin
     return unless self.role == 'admin'
-    # if User.where(role: 'admin').count == 1
-      # errors.add(:base, "最後一位管理員無法刪除")
-      # throw :abort
       if User.where(role: 'admin').count == 1
-        # halt msg: t('admin.final.admin')
         halt msg: "最後一位使用者無法被刪除"
       end
   end
 
-  def admin_edit
-    if self.role == 'admin'
-      self.update_all
-    end
-  end
 end

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -8,8 +8,7 @@
           <%= simple_form_for [:admin, @user] do |f| %>
             <div class="form-inputs">
               <%= f.input :username,label: t('views.user.username'), required: false, autofocus: true %>
-              <%= f.input :password,label: t('views.user.password'), required: false %>
-              <%= f.input :role, label: "管理身份", collection: [:menber, :admin] %>
+              <%= f.input :role, label: t('admin.identity'), collection: [:menber, :admin] %>
             </div>
 
             <div class="form-actions">

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -9,6 +9,7 @@
             <div class="form-inputs">
               <%= f.input :username,label: t('views.user.username'), required: false, autofocus: true %>
               <%= f.input :password,label: t('views.user.password'), required: false %>
+              <%= f.input :role, label: "管理身份", collection: [:menber, :admin] %>
             </div>
 
             <div class="form-actions">

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -16,16 +16,12 @@
       <td ><%= link_to user.username, admin_user_path(user) %></td>
       <td ><%= user.email %></td>
       <td ><%= user.tasks_count %></td>
-      <td>
-      <%= form_for [:admin, user] do |f| %>
-        <%= f.select :role, options_for_select([[t("admin.menber"),"menber"],[t("admin.admin"),"admin"]], user.role), {}, onchange: 'this.form.submit();' %>
-      <% end %>
-      </td>
+      <td ><%= user.role %></td>
       <td class="user-table-control">
         <%= link_to t('user.edit'), edit_admin_user_path(user), class: 'btn btn-outline-secondary btn-sm btn-edit' %>
         <%= link_to t('user.delete'), admin_user_path(user),data: {:confirm => t('admin.delete_msg') }, method: :delete, class:"btn btn-outline-secondary btn-sm btn-delete" %>
       </td>
     </tr>
-    <%end%>
+    <% end %>
   </tbody>
 </table>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -6,6 +6,7 @@
       <th scope="col"><%= t('views.user.username') %></th>
       <th sope="col"><%= t('views.user.email') %></th>
       <th sope="col"><%= t('views.user.tasks_count') %></th>
+      <th sope="col"><%= t('admin.identity') %></th>
       <th class="user-table-control" scope="col"> </th>
     </tr>
   </thead>
@@ -15,6 +16,11 @@
       <td ><%= link_to user.username, admin_user_path(user) %></td>
       <td ><%= user.email %></td>
       <td ><%= user.tasks_count %></td>
+      <td>
+      <%= form_for [:admin, user] do |f| %>
+        <%= f.select :role, options_for_select([[t("admin.menber"),"menber"],[t("admin.admin"),"admin"]], user.role), {}, onchange: 'this.form.submit();' %>
+      <% end %>
+      </td>
       <td class="user-table-control">
         <%= link_to t('user.edit'), edit_admin_user_path(user), class: 'btn btn-outline-secondary btn-sm btn-edit' %>
         <%= link_to t('user.delete'), admin_user_path(user),data: {:confirm => t('admin.delete_msg') }, method: :delete, class:"btn btn-outline-secondary btn-sm btn-delete" %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -17,11 +17,10 @@
       <div class="dropdown-menu" aria-labelledby="navbarDropdown">
         <%= link_to t('user.profile'),  user_path(current_user), class: 'dropdown-item' %>
         <%= link_to t('user.edit'),  edit_user_path(current_user), class: 'dropdown-item' %>
+        <%= link_to t('admin.back_end'), admin_users_path, class: 'dropdown-item' %>
+        <%= link_to t('admin.front_end'), root_path, class: 'dropdown-item' %>
         <div class="dropdown-divider"></div>
         <%= link_to t('user.logout'), logout_path, method: "delete", class: 'dropdown-item' %>
-        <% if current_user.role == 'admin' %>
-        <%= link_to "管理者介面", admin_users_path, class: 'dropdown-item' %>
-        <% end %>
       </div>
   </li>
   <% else %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
         <%= link_to t('user.edit'),  edit_user_path(current_user), class: 'dropdown-item' %>
         <div class="dropdown-divider"></div>
         <%= link_to t('user.logout'), logout_path, method: "delete", class: 'dropdown-item' %>
-        <% if current_user.role == 'admin' %>
+        <% if self.is_admin? %>
         <%= link_to "管理者介面", admin_users_path, class: 'dropdown-item' %>
         <% end %>
       </div>
@@ -43,5 +43,28 @@
   <div class="container">
     <%= yield %>
   </div>
+
+  <script>
+
+    $( "#dropdown" ).select2({
+      language: "zh-TW"
+    });
+    $(document).on('turbolinks:load', function(){
+      $("#task_tag_items").select2({
+        tags: true,
+        createTag: function(params){
+          var term = $.trim(params.term);
+          if(term === '') {
+            return null;
+        }
+          return {
+            id: term,
+            text: term,
+            newTag: true
+          }
+        }
+      })
+    });
+  </script>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
         <%= link_to t('user.edit'),  edit_user_path(current_user), class: 'dropdown-item' %>
         <div class="dropdown-divider"></div>
         <%= link_to t('user.logout'), logout_path, method: "delete", class: 'dropdown-item' %>
-        <% if self.is_admin? %>
+        <% if is_admin? %>
         <%= link_to "管理者介面", admin_users_path, class: 'dropdown-item' %>
         <% end %>
       </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,7 +6,8 @@
       </div>
       <div class="card-body">
         <p><%= t('views.user.username') %>: <%= @user.username %></p>          
-        <p><%= t('views.user.email') %>: <%= @user.email %></p>          
+        <p><%= t('views.user.email') %>: <%= @user.email %></p>
+        <p><%= t('admin.identity') %>: <%= identity(@user.role) %></p>           
       </div>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,4 +93,10 @@ zh-TW:
     destroy:
       notice: "delete done"
       notice_f: "destroy false"
+    identity: "identity"
+    menber: "menber"
+    admin: "admin"
+    not_admin: "you are not admin"
+    back_end: "admin_back_end"
+    front_end: "front_end"
   

--- a/config/locales/zh-TW.yml
+++ b/config/locales/zh-TW.yml
@@ -37,7 +37,7 @@ zh-TW:
     user:
       username: "帳號"
       email: "信箱"
-      tasks_count: "任務數量"
+      tasks_count: "數量"
       password: "密碼"
       sign_up: "註冊"
       create: "註冊完成"
@@ -93,4 +93,11 @@ zh-TW:
     destroy:
       notice: "刪除此使用者"
       notice_f: "刪除失敗"
+    identity: "身份"
+    menber: "會員"
+    admin: "管理員"
+    not_admin: "您的權限不足"
+    final_admin: "最後一位使用者無法刪除囉"
+    back_end: "後台管理"
+    front_end: "前台管理"
       

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
       get :search
     end
   end
-  resources :users, only: %i[show new create edit update]
+  resources :users, controller: 'users'
 
   resources :sessions
 

--- a/db/migrate/20191116091933_add_role_column_to_users.rb
+++ b/db/migrate/20191116091933_add_role_column_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleColumnToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :role, :string, default: 'menber'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_14_103854) do
+ActiveRecord::Schema.define(version: 2019_11_16_091933) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 2019_11_14_103854) do
     t.datetime "updated_at", null: false
     t.string "password_digest"
     t.integer "tasks_count"
+    t.string "role", default: "menber"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,7 +13,7 @@
 # }
 
 puts "建立人造人1號"
-user1 = User.create(username: "人造人17號", email: "robot17@gmail.com", password: '123456')
+user1 = User.create(username: "人造人17號", email: "robot17@gmail.com", password: '123456', role: 'admin')
 puts "以建立"
 puts "Generating 10 Task..."
 10.times do |i|


### PR DESCRIPTION
步驟22: 為使用者加入角色
將使用者分為管理員和一般使用者
請改成只有管理員可以存取使用者管理頁面
若一般使用者存取管理頁面時，需提示權限不足訊息無法存取，並轉向適當頁面
能在使用者管理頁面選擇角色
管理者只剩下一個人時，不能再被刪除
利用 model 的 callback 實做
※ 可以自己決定是否要使用 Gem